### PR TITLE
Windows batch script examples

### DIFF
--- a/Examples/export-example.bat
+++ b/Examples/export-example.bat
@@ -1,0 +1,35 @@
+@echo off
+
+:: !IMPORTANT! Which maps to export. Can use "*" as a wildcard, for example "de_*,cs_*".
+SET MAPS="de_overpass,de_cache,de_cbble"
+
+:: !IMPORTANT! Directory to export to.
+SET OUTPUT_DIR="exported"
+
+:: !IMPORTANT! Should be the root URL of where the exported files will be on your web server.
+:: For example, if the output directory will be at "http://your-website.com/foo/exported", this
+:: should be either "/foo/exported" or "http://your-website.com/foo/exported"
+SET URL_PREFIX="/"
+
+:: This can be set to "true" if you wish to pause at the end of the script (eg. debugging purposes)
+SET SHOULD_PAUSE="false"
+
+:: Game install folder (should work for other Source games)
+SET GAME_DIR="C:\Program Files (x86)\Steam\steamapps\common\Counter-Strike Global Offensive\csgo"
+
+:: Where to look for the specified maps, relative to the game install folder
+SET MAPS_DIR="maps"
+
+:: Extra options: --overwrite, --verbose, --untextured
+SET OPTIONS="--overwrite --verbose"
+
+"bin\SourceUtils.WebExport.exe" ^
+export ^
+    --maps %MAPS% ^
+    --outdir %OUTPUT_DIR% ^
+    --gamedir %GAME_DIR% ^
+    --mapsdir %MAPS_DIR% ^
+    --url-prefix %URL_PREFIX% ^
+    %OPTIONS:"=%
+
+if %SHOULD_PAUSE% == "true" pause

--- a/Examples/host-example.bat
+++ b/Examples/host-example.bat
@@ -1,0 +1,28 @@
+@echo off
+
+:: Map to open in your web browser
+SET INITIAL_MAP="de_mirage"
+
+:: This can be set to "true" if you wish to pause at the end of the script (eg. debugging purposes)
+SET SHOULD_PAUSE="false"
+
+:: Game install folder (should work for other Source games)
+SET GAME_DIR="C:\Program Files (x86)\Steam\steamapps\common\Counter-Strike Global Offensive\csgo"
+
+:: Where to look for maps, relative to the game install folder
+SET MAPS_DIR="maps"
+
+:: Launch a browser window
+start "" "http://localhost:8080/maps/%INITIAL_MAP%/index.html"
+
+:: Extra options: --overwrite, --verbose, --untextured
+SET OPTIONS="--untextured"
+
+echo Launching web server...
+"bin\SourceUtils.WebExport.exe" ^
+host ^
+    --gamedir %GAME_DIR% ^
+    --mapsdir %MAPS_DIR% ^
+    %OPTIONS:"=%
+
+if %SHOULD_PAUSE% == "true" pause


### PR DESCRIPTION
These scripts are mainly the same as ones from the release versions.
NOTE: Host example is untested.

There are 3 changes to the release version:

- Fixed "OPTIONS" variable comment on host example.
- Fixed "OPTIONS" variable passing due to extra quotes being set.
- Implemented a "SHOULD_PAUSE" variable to pause the terminal in case the user wants to, this defaults to false to keep backwards compability.