### PR TITLE
Fixed float to string conversion not being culture invariant

### DIFF
--- a/SourceUtils.WebExport/ResourceController.cs
+++ b/SourceUtils.WebExport/ResourceController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.NetworkInformation;
@@ -184,7 +185,7 @@ namespace SourceUtils.WebExport
 
             foreach ( var item in this )
             {
-                _sStringBuilder.Append( item.ToString( formatString ).TrimEnd( '0' ).TrimEnd( '.' ) );
+                _sStringBuilder.Append( item.ToString( formatString, CultureInfo.InvariantCulture ).TrimEnd( '0' ).TrimEnd( '.' ) );
                 _sStringBuilder.Append( "," );
             }
 
@@ -308,7 +309,7 @@ namespace SourceUtils.WebExport
 
             if ( floatArr != null )
             {
-                raw = string.Join( ",", floatArr );
+                raw = string.Join( ",", floatArr.Select(f => f.ToString(CultureInfo.InvariantCulture)).ToArray());
             }
             else if ( intArr != null )
             {


### PR DESCRIPTION
In swedish and some other languages, comma is used as decimal point so when converting the floats to string they would become "10,123" for example, which would get mixed into the regular value separating commas and break the json files.