### PR TITLE
Some fixes from years ago

### DIFF
--- a/SourceUtils.WebExport/Material.cs
+++ b/SourceUtils.WebExport/Material.cs
@@ -196,6 +196,9 @@ namespace SourceUtils.WebExport
                     case "$hdrcompressedtexture":
                         mat.SetTextureUrl("hdrcompressedtexture", GetTextureUrl(value, vmtPath, bsp));
                         break;
+                    case "$hdrbasetexture":
+                        mat.SetTextureUrl("hdrbasetexture", GetTextureUrl(value, vmtPath, bsp));
+                        break;
                     case "$texture2":
                     case "$basetexture2":
                         mat.SetTextureUrl("basetexture2", GetTextureUrl(value, vmtPath, bsp));
@@ -318,6 +321,7 @@ namespace SourceUtils.WebExport
                 if ( mat == null ) continue;
 
                 var texProp = mat.Properties.FirstOrDefault( x => x.Name == "hdrcompressedtexture")
+                    ?? mat.Properties.FirstOrDefault(x => x.Name == "hdrbasetexture")
                     ?? mat.Properties.First(x => x.Name == "basetexture");
 
                 if ( face == 0 )

--- a/SourceUtils.WebExport/Texture.Convert.cs
+++ b/SourceUtils.WebExport/Texture.Convert.cs
@@ -190,6 +190,9 @@ namespace SourceUtils.WebExport
                 case TextureFormat.ABGR8888:
                     readSettings.PixelStorage = new PixelStorageSettings(StorageType.Char, "ABGR");
                     break;
+                case TextureFormat.ARGB8888:
+                    readSettings.PixelStorage = new PixelStorageSettings(StorageType.Char, "ARGB");
+                    break;
                 case TextureFormat.BGRA8888:
                     readSettings.PixelStorage = new PixelStorageSettings(StorageType.Char, "BGRA");
                     break;

--- a/SourceUtils.WebExport/Texture.Convert.cs
+++ b/SourceUtils.WebExport/Texture.Convert.cs
@@ -164,6 +164,11 @@ namespace SourceUtils.WebExport
                     break;
                 case TextureFormat.I8:
                     readSettings.Format = MagickFormat.Gray;
+                    readSettings.PixelStorage = new PixelStorageSettings
+                    {
+                        StorageType = StorageType.Char,
+                        Mapping = "P"
+                    };
                     break;
                 case TextureFormat.IA88:
                     readSettings.Format = MagickFormat.Gray;

--- a/SourceUtils/KeyValues.cs
+++ b/SourceUtils/KeyValues.cs
@@ -328,7 +328,7 @@ namespace SourceUtils
 
             if ( !result.Success )
             {
-                throw new KeyValuesParserException( result );
+                return null;
             }
 
             return new KeyValues( result.First(), flags );
@@ -343,7 +343,7 @@ namespace SourceUtils
 
             if ( !result.Success )
             {
-                throw new KeyValuesParserException( result );
+                yield return null;
             }
 
             foreach ( var parsed in result )

--- a/SourceUtils/SourceUtils.csproj
+++ b/SourceUtils/SourceUtils.csproj
@@ -35,9 +35,8 @@
     <Reference Include="Facepunch.Parse, Version=0.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Facepunch.Parse.0.1.0-CI00040\lib\net35\Facepunch.Parse.dll</HintPath>
     </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=1.3.3.11, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpZipLib.1.3.3\lib\net45\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/SourceUtils/ValveMaterialFile.cs
+++ b/SourceUtils/ValveMaterialFile.cs
@@ -33,6 +33,14 @@ namespace SourceUtils
                 vmt = new ValveMaterialFile( stream );
             }
             
+            if ( vmt.Shaders == null )
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.WriteLine($"Material '{path}' parsing failed!");
+                Console.ResetColor();
+                return null;
+            }
+
             if ( !vmt.Shaders.Any() ) return null;
 
             var shader = vmt.Shaders.First();
@@ -67,7 +75,7 @@ namespace SourceUtils
             _keyValues = KeyValues.FromStream( stream );
         }
 
-        public IEnumerable<string> Shaders => _keyValues.Keys;
+        public IEnumerable<string> Shaders => _keyValues == null ? null : _keyValues.Keys;
 
         public bool ContainsShader(string shader)
         {

--- a/SourceUtils/ValveTextureFile.cs
+++ b/SourceUtils/ValveTextureFile.cs
@@ -168,6 +168,7 @@ namespace SourceUtils
                 case TextureFormat.IA88:
                     return toAdd + (width * height * depth) << 1;
                 case TextureFormat.ABGR8888:
+                case TextureFormat.ARGB8888:
                 case TextureFormat.BGRA8888:
                 case TextureFormat.RGBA8888:
                     return toAdd + ((width * height * depth) << 2);
@@ -294,6 +295,7 @@ namespace SourceUtils
                 case TextureFormat.RGB888:
                 case TextureFormat.RGB888_BLUESCREEN:
                 case TextureFormat.ABGR8888:
+                case TextureFormat.ARGB8888:
                 case TextureFormat.BGRA8888:
                 case TextureFormat.RGBA8888:
                 case TextureFormat.RGBA16161616F:


### PR DESCRIPTION
Seeing as this is being updated again, here's a PR of some stuff I fixed when converting every global KZ map 4 years ago.

> Add support for ARGB8888 format
> Add support for $hdrbasetexture, convert RGBA16F to RGBA8
> Fix I8 texture format hanging and crashing the program (redundant)
> Fix broken vmt files crashing all of material conversion

Also changed mapping of I8 from R to P.
Any chance for a source2utils and source2replayviewer ;)))